### PR TITLE
Check smtplib.SMTP.blockage when monkeypatching SMTP

### DIFF
--- a/blockage/plugins.py
+++ b/blockage/plugins.py
@@ -77,7 +77,7 @@ class NoseBlockage(Plugin):
 
         whitelisted.blockage = True
 
-        if not getattr(httplib.HTTPConnection, 'blockage', False):
+        if not getattr(smtplib.SMTP, 'blockage', False):
             log.debug('Monkey patching smtplib')
             smtplib.SMTP.old = smtplib.SMTP.__init__
             smtplib.SMTP.__init__ = whitelisted


### PR DESCRIPTION
Updates SMTP monkeypatching to check smtplib.SMTP for a 'blockage' attr (instead of httplib.HTTPConnection).

I haven't run it, but it looked wrong by inspection. :)
